### PR TITLE
McKade - Explore Items Page

### DIFF
--- a/src/components/UI/ItemCard.jsx
+++ b/src/components/UI/ItemCard.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Timer from "./Timer";
+
+const ItemCard = ({ item }) => {
+  return (
+    <div className="item" key={item.id}>
+      <div className="nft__item">
+        <div className="author_list_pp">
+          <Link
+            to={`/author/${item.authorId}`}
+            // data-bs-toggle="tooltip"
+            // data-bs-placement="top"
+            // TODO: Get author's name here somehow
+            // title={`Creator: ${item.authorId}`}
+          >
+            <img className="lazy" src={item.authorImage} alt="" />
+            <i className="fa fa-check"></i>
+          </Link>
+        </div>
+        <Timer expiryDate={item.expiryDate} />
+
+        <div className="nft__item_wrap">
+          {/* <div className="nft__item_extra"> */}
+          {/*   <div className="nft__item_buttons"> */}
+          {/*     <button>Buy Now</button> */}
+          {/*     <div className="nft__item_share"> */}
+          {/*       <h4>Share</h4> */}
+          {/*       <a href="" target="_blank" rel="noreferrer"> */}
+          {/*         <i className="fa fa-facebook fa-lg"></i> */}
+          {/*       </a> */}
+          {/*       <a href="" target="_blank" rel="noreferrer"> */}
+          {/*         <i className="fa fa-twitter fa-lg"></i> */}
+          {/*       </a> */}
+          {/*       <a href=""> */}
+          {/*         <i className="fa fa-envelope fa-lg"></i> */}
+          {/*       </a> */}
+          {/*     </div> */}
+          {/*   </div> */}
+          {/* </div> */}
+
+          <Link to={`/item-details/${item.nftId}`}>
+            <img
+              src={item.nftImage}
+              className="lazy nft__item_preview"
+              alt="NFT"
+            />
+          </Link>
+        </div>
+        <div className="nft__item_info">
+          <Link to={`/item-details/${item.nftId}`}>
+            <h4>{item.title}</h4>
+          </Link>
+          <div className="nft__item_price">{item.price} ETH</div>
+          <div className="nft__item_like">
+            <i className="fa fa-heart"></i>
+            <span>{item.likes}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default ItemCard;

--- a/src/components/UI/SkeletonItemCard.jsx
+++ b/src/components/UI/SkeletonItemCard.jsx
@@ -1,0 +1,49 @@
+import React from "react";
+
+const SkeletonItemCard = ({ index }) => {
+  return (
+    <div className="item" key={index}>
+      <div className="nft__item">
+        <div className="author_list_pp">
+          <div
+            className="skeleton-box"
+            style={{
+              width: "50px",
+              height: "50px",
+              borderRadius: "50%",
+            }}
+          />
+          <i className="fa fa-check"></i>
+        </div>
+
+        <div className="nft__item-wrap">
+          <div
+            className="skeleton-box"
+            style={{ width: "100%", height: "350px" }}
+          />
+        </div>
+
+        <div className="nft__item_info">
+          <div
+            className="skeleton-box"
+            style={{ width: "150px", height: "30px" }}
+          />
+          <div className="nft__item_price">
+            <div
+              className="skeleton-box"
+              style={{ width: "75px", height: "20px" }}
+            />
+          </div>
+          <div className="nft__item_like">
+            <div
+              className="skeleton-box"
+              style={{ width: "25px", height: "15px" }}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default SkeletonItemCard;

--- a/src/components/explore/ExploreItems.jsx
+++ b/src/components/explore/ExploreItems.jsx
@@ -1,78 +1,77 @@
-import React from "react";
+import axios from "axios";
+import React, { useEffect, useState } from "react";
 import { Link } from "react-router-dom";
-import AuthorImage from "../../images/author_thumbnail.jpg";
-import nftImage from "../../images/nftImage.jpg";
+import ItemCard from "../UI/ItemCard";
+import SkeletonItemCard from "../UI/SkeletonItemCard";
 
 const ExploreItems = () => {
+  const [loading, setLoading] = useState(true);
+  const [items, setItems] = useState([]);
+  const [filter, setFilter] = useState("");
+  const [itemsToShow, setItemsToShow] = useState(8);
+
+  useEffect(() => {
+    async function getItems() {
+      const { data } = await axios.get(
+        `https://us-central1-nft-cloud-functions.cloudfunctions.net/explore?filter=${filter}`,
+      );
+
+      setItems(data.slice(0, itemsToShow));
+      setLoading(false);
+    }
+
+    getItems();
+  }, [filter, itemsToShow]);
+
   return (
     <>
       <div>
-        <select id="filter-items" defaultValue="">
+        <select
+          id="filter-items"
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+        >
           <option value="">Default</option>
           <option value="price_low_to_high">Price, Low to High</option>
           <option value="price_high_to_low">Price, High to Low</option>
           <option value="likes_high_to_low">Most liked</option>
         </select>
       </div>
-      {new Array(8).fill(0).map((_, index) => (
-        <div
-          key={index}
-          className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
-          style={{ display: "block", backgroundSize: "cover" }}
-        >
-          <div className="nft__item">
-            <div className="author_list_pp">
-              <Link
-                to="/author"
-                data-bs-toggle="tooltip"
-                data-bs-placement="top"
-              >
-                <img className="lazy" src={AuthorImage} alt="" />
-                <i className="fa fa-check"></i>
-              </Link>
-            </div>
-            <div className="de_countdown">5h 30m 32s</div>
-
-            <div className="nft__item_wrap">
-              <div className="nft__item_extra">
-                <div className="nft__item_buttons">
-                  <button>Buy Now</button>
-                  <div className="nft__item_share">
-                    <h4>Share</h4>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-facebook fa-lg"></i>
-                    </a>
-                    <a href="" target="_blank" rel="noreferrer">
-                      <i className="fa fa-twitter fa-lg"></i>
-                    </a>
-                    <a href="">
-                      <i className="fa fa-envelope fa-lg"></i>
-                    </a>
-                  </div>
-                </div>
-              </div>
-              <Link to="/item-details">
-                <img src={nftImage} className="lazy nft__item_preview" alt="" />
-              </Link>
-            </div>
-            <div className="nft__item_info">
-              <Link to="/item-details">
-                <h4>Pinky Ocean</h4>
-              </Link>
-              <div className="nft__item_price">1.74 ETH</div>
-              <div className="nft__item_like">
-                <i className="fa fa-heart"></i>
-                <span>69</span>
-              </div>
-            </div>
+      {loading ? (
+        new Array(8).fill(0).map((_, index) => (
+          <div
+            key={index}
+            className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+            style={{ display: "block", backgroundSize: "cover" }}
+          >
+            <SkeletonItemCard index={index} />
           </div>
+        ))
+      ) : (
+        <>
+          {items.map((item) => (
+            <div
+              key={item.id}
+              className="d-item col-lg-3 col-md-6 col-sm-6 col-xs-12"
+              style={{ display: "block", backgroundSize: "cover" }}
+            >
+              <ItemCard item={item} />
+            </div>
+          ))}
+        </>
+      )}
+      {itemsToShow < 16 && (
+        <div className="col-md-12 text-center">
+          <Link
+            to="/explore"
+            id="loadmore"
+            className="btn-main lead"
+            onClick={() => setItemsToShow(itemsToShow + 4)}
+          >
+            Load more
+          </Link>
         </div>
-      ))}
-      <div className="col-md-12 text-center">
-        <Link to="" id="loadmore" className="btn-main lead">
-          Load more
-        </Link>
-      </div>
+      )}
     </>
   );
 };

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -7,6 +7,8 @@ import "owl.carousel/dist/assets/owl.carousel.css";
 import "owl.carousel/dist/assets/owl.theme.default.css";
 
 import Timer from "../UI/Timer";
+import ItemCard from "../UI/ItemCard";
+import SkeletonItemCard from "../UI/SkeletonItemCard";
 
 const NewItems = () => {
   const [loading, setLoading] = useState(true);
@@ -67,106 +69,10 @@ const NewItems = () => {
             nav
           >
             {!loading
-              ? items.map((item, index) => (
-                  <div className="item" key={index}>
-                    <div className="nft__item">
-                      <div className="author_list_pp">
-                        <Link
-                          to={`/author/${item.authorId}`}
-                          // data-bs-toggle="tooltip"
-                          // data-bs-placement="top"
-                          // TODO: Get author's name here somehow
-                          // title={`Creator: ${item.authorId}`}
-                        >
-                          <img className="lazy" src={item.authorImage} alt="" />
-                          <i className="fa fa-check"></i>
-                        </Link>
-                      </div>
-                      <Timer expiryDate={item.expiryDate} />
-
-                      <div className="nft__item_wrap">
-                        {/* <div className="nft__item_extra"> */}
-                        {/*   <div className="nft__item_buttons"> */}
-                        {/*     <button>Buy Now</button> */}
-                        {/*     <div className="nft__item_share"> */}
-                        {/*       <h4>Share</h4> */}
-                        {/*       <a href="" target="_blank" rel="noreferrer"> */}
-                        {/*         <i className="fa fa-facebook fa-lg"></i> */}
-                        {/*       </a> */}
-                        {/*       <a href="" target="_blank" rel="noreferrer"> */}
-                        {/*         <i className="fa fa-twitter fa-lg"></i> */}
-                        {/*       </a> */}
-                        {/*       <a href=""> */}
-                        {/*         <i className="fa fa-envelope fa-lg"></i> */}
-                        {/*       </a> */}
-                        {/*     </div> */}
-                        {/*   </div> */}
-                        {/* </div> */}
-
-                        <Link to={`/item-details/${item.nftId}`}>
-                          <img
-                            src={item.nftImage}
-                            className="lazy nft__item_preview"
-                            alt="NFT"
-                          />
-                        </Link>
-                      </div>
-                      <div className="nft__item_info">
-                        <Link to={`/item-details/${item.nftId}`}>
-                          <h4>{item.title}</h4>
-                        </Link>
-                        <div className="nft__item_price">{item.price} ETH</div>
-                        <div className="nft__item_like">
-                          <i className="fa fa-heart"></i>
-                          <span>{item.likes}</span>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))
-              : new Array(4).fill(0).map((_, index) => (
-                  <div className="item" key={index}>
-                    <div className="nft__item">
-                      <div className="author_list_pp">
-                        <div
-                          className="skeleton-box"
-                          style={{
-                            width: "50px",
-                            height: "50px",
-                            borderRadius: "50%",
-                          }}
-                        />
-                        <i className="fa fa-check"></i>
-                      </div>
-
-                      <div className="nft__item-wrap">
-                        <div
-                          className="skeleton-box"
-                          style={{ width: "100%", height: "350px" }}
-                        />
-                      </div>
-
-                      <div className="nft__item_info">
-                        <div
-                          className="skeleton-box"
-                          style={{ width: "150px", height: "30px" }}
-                        />
-                        <div className="nft__item_price">
-                          <div
-                            className="skeleton-box"
-                            style={{ width: "75px", height: "20px" }}
-                          />
-                        </div>
-                        <div className="nft__item_like">
-                          <div
-                            className="skeleton-box"
-                            style={{ width: "25px", height: "15px" }}
-                          />
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+              ? items.map((item) => <ItemCard item={item} />)
+              : new Array(4)
+                  .fill(0)
+                  .map((_, index) => <SkeletonItemCard index={index} />)}
           </OwlCarousel>
         </div>
       </div>

--- a/src/components/home/NewItems.jsx
+++ b/src/components/home/NewItems.jsx
@@ -1,12 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Link } from "react-router-dom";
 import axios from "axios";
 
 import OwlCarousel from "react-owl-carousel";
 import "owl.carousel/dist/assets/owl.carousel.css";
 import "owl.carousel/dist/assets/owl.theme.default.css";
 
-import Timer from "../UI/Timer";
 import ItemCard from "../UI/ItemCard";
 import SkeletonItemCard from "../UI/SkeletonItemCard";
 


### PR DESCRIPTION
Implemented dynamic data for explore items page
Implemented reusable components for displaying nft cards and skeleton loading cards
Data can now be filtered using the option select on the explore page
Implemented 'load more' functionality (4 at a time)

- Used axios to get relevant data for the card components (same card ui as newItems)
- Re used newItems skeleton loading state for these cards as well
- Modified filter property at the end of the API's url based on which sorting option is selected on the explore page to filter through NFT's gracefully
- Initial set of data is sliced to be a maximum of 8 objects, clicking on 'load more' at the bottom adds 4 to this variable and displays the next relevant NFTs based on the filter

<img width="685" height="872" alt="McKade-ExploreItems-PR-Greenshot" src="https://github.com/user-attachments/assets/49acd068-fd91-49a6-ba28-b797dff46d06" />